### PR TITLE
Implement Output Buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Provides a custom post type, taxonomies and help functions for describing degree
 2. Activate the plugin through the "Plugins" screen in WordPress
 
 ### WP CLI Installation ###
-1. `$ wp plugin install --activate https://github.com/UCF/UCF-Degree-CPT/archive/master.zip`.  See [WP-CLI Docs](http://wp-cli.org/commands/plugin/install/) for more command options.
+1. `$ wp plugin install --activate https://github.com/UCF/UCF-Degree-CPT-Plugin/archive/master.zip`.  See [WP-CLI Docs](http://wp-cli.org/commands/plugin/install/) for more command options.
 
 
 ## Changelog ##

--- a/common/ucf-degree-career-paths-common.php
+++ b/common/ucf-degree-career-paths-common.php
@@ -5,6 +5,8 @@
 if ( ! class_exists( 'UCF_Degree_Career_Paths_Common' ) ) {
 	class UCF_Degree_Career_Paths_Common {
 		public function display_career_paths( $items, $layout, $title, $display_type='default' ) {
+			ob_start();
+
 			// Display before
 			if ( has_action( 'ucf_career_paths_display_' . $layout . '_before' ) ) {
 				do_action( 'ucf_career_paths_display_' . $layout . '_before', $items, $title, $display_type );
@@ -24,6 +26,8 @@ if ( ! class_exists( 'UCF_Degree_Career_Paths_Common' ) ) {
 			if ( has_action( 'ucf_career_paths_display_' . $layout . '_after' ) ) {
 				do_action( 'ucf_career_paths_display_' . $layout . '_after', $items, $title, $display_type );
 			}
+
+			return ob_get_clean();
 		}
 	}
 }

--- a/common/ucf-degree-list-common.php
+++ b/common/ucf-degree-list-common.php
@@ -5,6 +5,8 @@
 if ( ! class_exists( 'UCF_Degree_List_Common' ) ) {
 	class UCF_Degree_List_Common {
 		public function display_degrees( $items, $layout, $title, $display_type='default', $grouped=false, $groupby_field=null ) {
+			ob_start();
+
 			// Display before
 			if ( has_action( 'ucf_degree_list_display_' . $layout . '_before' ) ) {
 				do_action( 'ucf_degree_list_display_' . $layout . '_before', $items, $title, $display_type );
@@ -29,6 +31,8 @@ if ( ! class_exists( 'UCF_Degree_List_Common' ) ) {
 			if ( has_action( 'ucf_degree_list_display_' . $layout . '_after' ) ) {
 				do_action( 'ucf_degree_list_display_' . $layout . '_after', $items, $title, $display_type );
 			}
+
+			return ob_get_clean();
 		}
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -22,7 +22,7 @@ Provides a custom post type, taxonomies and help functions for describing degree
 2. Activate the plugin through the "Plugins" screen in WordPress
 
 = WP CLI Installation =
-1. `$ wp plugin install --activate https://github.com/UCF/UCF-Degree-CPT/archive/master.zip`.  See [WP-CLI Docs](http://wp-cli.org/commands/plugin/install/) for more command options.
+1. `$ wp plugin install --activate https://github.com/UCF/UCF-Degree-CPT-Plugin/archive/master.zip`.  See [WP-CLI Docs](http://wp-cli.org/commands/plugin/install/) for more command options.
 
 
 == Changelog ==

--- a/shortcodes/ucf-degree-career-paths-shortcode.php
+++ b/shortcodes/ucf-degree-career-paths-shortcode.php
@@ -19,7 +19,7 @@ if ( ! class_exists( 'UCF_Degree_Career_Paths_List_Shortcode' ) ) {
 				'title'     => null
 			), $atts);
 
-			$post = null;
+			$_post = null;
 
 			if ( $atts['post_slug'] ) {
 				$args = array(
@@ -30,17 +30,17 @@ if ( ! class_exists( 'UCF_Degree_Career_Paths_List_Shortcode' ) ) {
 
 				$posts = get_posts( $args );
 
-				$post = is_array( $posts ) ? $posts[0] : null;
+				$_post = is_array( $posts ) ? $posts[0] : null;
 			}
 
-			if ( ! $post ) {
+			if ( ! $_post ) {
 				global $post;
+				$_post = $post;
 			}
 
-			if ( $post ) {
-				$items = wp_get_post_terms( $post->ID, 'career_paths' );
-
-				UCF_Degree_Career_Paths_Common::display_career_paths( $items, $atts['layout'], $atts['title'] );
+			if ( $_post ) {
+				$items = wp_get_post_terms( $_post->ID, 'career_paths' );
+				return UCF_Degree_Career_Paths_Common::display_career_paths( $items, $atts['layout'], $atts['title'] );
 			}
 		}
 	}

--- a/shortcodes/ucf-degree-list-shortcode.php
+++ b/shortcodes/ucf-degree-list-shortcode.php
@@ -43,7 +43,7 @@ if ( ! class_exists( 'UCF_Degree_List_Shortcode' ) ) {
 
 			$grouped = ! empty( $atts['groupby'] ) ? true : false;
 
-			UCF_Degree_List_Common::display_degrees( $posts, 'classic', $atts['title'], 'default', $grouped, $atts['groupby_field'] );
+			return UCF_Degree_List_Common::display_degrees( $posts, 'classic', $atts['title'], 'default', $grouped, $atts['groupby_field'] );
 		}
 	}
 

--- a/ucf-degree-cpt.php
+++ b/ucf-degree-cpt.php
@@ -52,6 +52,10 @@ add_action( 'plugins_loaded', function() {
 		add_action( 'init', array( 'UCF_Degree_API', 'register_rest_routes' ) );
 	}
 
+	if ( ! shortcode_exists( 'career-paths' ) ) {
+		add_shortcode( 'career-paths', array( 'UCF_Degree_Career_Paths_List_Shortcode', 'shortcode' ) );
+	}
+
 	add_action( 'admin_enqueue_scripts', array( 'UCF_Degree_Admin', 'enqueue_admin_scripts' ) );
 } );
 


### PR DESCRIPTION
This change updates the common functions to return the markup using output buffers instead of directly echoing it. When the shortcodes were being processed through the `the_content` action, the output was being directly echoed out, causing the output to appear at the top of the content area instead of in the position in the content it was supposed to appear.