### PR TITLE
Sorted grouped degrees

### DIFF
--- a/common/ucf-degree-list-common.php
+++ b/common/ucf-degree-list-common.php
@@ -90,12 +90,9 @@ if ( ! function_exists( 'ucf_degree_list_display_classic_grouped' ) ) {
 	function ucf_degree_list_display_classic_grouped( $items, $title, $display_type, $groupby_field ) {
 		ob_start();
 		foreach( $items as $item ) : // For each group
-			$heading = ( ! empty( $groupby_field ) && isset( $item['term']['meta'][$groupby_field] ) )
-				? $item['term']['meta'][$groupby_field]
-				: $item['term']['name'];
 	?>
 		<div class="degree-list-group">
-			<h3 class="degree-list-heading"><?php echo $heading; ?></h3>
+			<h3 class="degree-list-heading"><?php echo $item['group_name']; ?></h3>
 			<?php echo ucf_degree_list_display_classic( $item['posts'], $title, $display_type ); ?>
 		</div>
 	<?php

--- a/includes/ucf-degree-utils.php
+++ b/includes/ucf-degree-utils.php
@@ -54,6 +54,8 @@ if ( ! function_exists( 'ucf_degree_group_by_tax_term' ) ) {
 			}
 		}
 
+		ksort( $retval );
+
 		return $retval;
 	}
 }

--- a/includes/ucf-degree-utils.php
+++ b/includes/ucf-degree-utils.php
@@ -54,8 +54,6 @@ if ( ! function_exists( 'ucf_degree_group_by_tax_term' ) ) {
 			}
 		}
 
-		ksort( $retval );
-
 		return $retval;
 	}
 }

--- a/shortcodes/ucf-degree-list-shortcode.php
+++ b/shortcodes/ucf-degree-list-shortcode.php
@@ -37,17 +37,29 @@ if ( ! class_exists( 'UCF_Degree_List_Shortcode' ) ) {
 				);
 			}
 
-			$posts = get_posts( $args );
-
-			if ( $atts['groupby'] ) {
-				$posts = ucf_degree_group_posts_by_tax( $atts['groupby'], $posts );
-			}
+			$items = get_posts( $args );
 
 			$grouped = ! empty( $atts['groupby'] ) ? true : false;
 
+			if ( $grouped ) {
+				$items = ucf_degree_group_posts_by_tax( $atts['groupby'], $items );
+
+				foreach ( $items as $key => $item ) {
+					$items[$key]['group_name'] = ( ! empty( $atts['groupby_field'] ) && isset( $item['term']['meta'][$atts['groupby_field']] ) )
+						? $item['term']['meta'][$atts['groupby_field']]
+						: $item['term']['name'];
+				}
+
+				usort( $items, array( 'UCF_Degree_List_Shortcode', 'sort_grouped_degrees' ) );
+			}
+
 			ob_start();
-			echo UCF_Degree_List_Common::display_degrees( $posts, 'classic', $atts['title'], 'default', $grouped, $atts['groupby_field'] );
+			echo UCF_Degree_List_Common::display_degrees( $items, 'classic', $atts['title'], 'default', $grouped, $atts['groupby_field'] );
 			return ob_get_clean();
+		}
+
+		public static function sort_grouped_degrees( $a, $b ) {
+			return strcmp( $a['group_name'], $b['group_name'] );
 		}
 	}
 


### PR DESCRIPTION
Adds a new 'group_name' value to each degree group item in the degree-list shortcode, which is set to the item's 'groupby_field' value, if it exists, or the item's term name.  Groups are then sorted alphabetically by each 'group_name'.

Visual example is in Dev, immediately underneath the degree search form.