### PR TITLE
Bug/notice fixes

### DIFF
--- a/includes/ucf-degree-posttype.php
+++ b/includes/ucf-degree-posttype.php
@@ -129,18 +129,18 @@ if ( ! class_exists( 'UCF_Degree_PostType' ) ) {
 		}
 
 		public static function taxonomies() {
-			$retval = array(
+			$retval = array();
+			$valid_taxonomies = array(
 				'post_tag',
 				'program_types',
 				'colleges',
 				'career_paths'
 			);
+			$valid_taxonomies = apply_filters( 'ucf_degree_taxonomies', $valid_taxonomies );
 
-			$retval = apply_filters( 'ucf_degree_taxonomies', $retval );
-
-			foreach( $retval as $taxonomy ) {
-				if ( ! taxonomy_exists( $taxonomy ) ) {
-					unset( $retval[$taxonomy] );
+			foreach( $valid_taxonomies as $taxonomy ) {
+				if ( taxonomy_exists( $taxonomy ) ) {
+					$retval[] = $taxonomy;
 				}
 			}
 

--- a/includes/ucf-degree-utils.php
+++ b/includes/ucf-degree-utils.php
@@ -119,9 +119,9 @@ if ( ! function_exists( 'ucf_degree_search_where_filter' ) ) {
 		if ( isset( $wp_query->query['degree_search'] ) && $wp_query->query_vars['post_type'] === 'degree' ) {
 			$s = $wp_query->query['degree_search'];
 			$where .= " AND (";
-			$where .= $wpdb::prepare( " lower($wpdb->posts.post_title) LIKE %s OR", '%' . $s . '%' );
-			$where .= $wpdb::prepare( " lower(wt.name) LIKE %s OR", '%' . $s . '%' );
-			$where .= $wpdb::prepare( " lower(wpm.meta_value) LIKE %s)", '%'. $s . '%' );
+			$where .= $wpdb->prepare( " lower($wpdb->posts.post_title) LIKE %s OR", '%' . $s . '%' );
+			$where .= $wpdb->prepare( " lower(wt.name) LIKE %s OR", '%' . $s . '%' );
+			$where .= $wpdb->prepare( " lower(wpm.meta_value) LIKE %s)", '%'. $s . '%' );
 		}
 
 		return $where;


### PR DESCRIPTION
- Fixes notices in the REST API causes by `UCF_Degree_PostType::taxonomies()` not properly unsetting invalid degree taxonomies in `$retval`, resulting in 'invalid taxonomy' error messages being present in subsequent lists of taxonomies, which would cause errors when term object properties would be called on those errors.
- Fixes incorrect usage of `$wpdb->prepare`, suppressing a few warnings in degree search API results.