### PR TITLE
Import overrides

### DIFF
--- a/importers/degree-importer.php
+++ b/importers/degree-importer.php
@@ -703,7 +703,7 @@ class UCF_Degree_Import {
 
 		// Allow overrides by themes/other plugins
 		if ( has_filter( 'ucf_degree_get_program_types' ) ) {
-			$program_types = apply_filters( 'ucf_degree_get_program_types', $program_types, $this );
+			$program_types = apply_filters( 'ucf_degree_get_program_types', $program_types, $this->program );
 		}
 
 		return $program_types;

--- a/importers/degree-importer.php
+++ b/importers/degree-importer.php
@@ -230,6 +230,12 @@ Degree Total    : {$degree_total}
 			list( $url, $results ) = $this->fetch_api_page( $url, $results );
 		}
 
+		// Allow returned results and result count to be overridden by
+		// other themes/plugins.
+		// Functions passed to this filter MUST return both $results AND $count
+		// as a two-value array.
+		list( $results, $count ) = apply_filters( 'ucf_degree_import_results', $results, $count, $this->api_key );
+
 		$this->result_count = $count;
 
 		WP_CLI::log( sprintf( '%s API results fetched.', $count ) );
@@ -566,6 +572,8 @@ class UCF_Degree_Import {
 	 * @return UCF_Degree_Import
 	 **/
 	public function __construct( $program, $api_key=null, $preserve_hierarchy=true ) {
+		$this->preserve_hierarchy = $preserve_hierarchy;
+
 		$this->program       = $program;
 		$this->plan_code     = $program->plan_code;
 		$this->subplan_code  = $program->subplan_code;
@@ -591,7 +599,6 @@ class UCF_Degree_Import {
 
 		$this->post_meta  = $this->get_post_metadata();
 		$this->post_terms = $this->get_post_terms();
-		$this->hierarchy  = $preserve_hierarchy;
 	}
 
 	/**

--- a/importers/degree-importer.php
+++ b/importers/degree-importer.php
@@ -24,7 +24,8 @@ class UCF_Degree_Importer {
 		$removed_count = 0,
 		$duplicate_count = 0,
 
-		$program_types = array(
+		$program_types = array(),
+		$default_program_types = array(
 			'Undergraduate Program' => array(
 				'Bachelor',
 				'Minor',
@@ -37,7 +38,7 @@ class UCF_Degree_Importer {
 				'Graduate Certificate'
 			),
 			'Professional Program'
-		); // Array of default program_types
+		);
 
 	/**
 	 * Constructor
@@ -53,6 +54,7 @@ class UCF_Degree_Importer {
 		$this->additional_params = $additional_params;
 		$this->api_key = $api_key;
 		$this->do_writebacks = $do_writebacks;
+		$this->program_types = apply_filters( 'ucf_degree_imported_program_types', $default_program_types );
 	}
 
 	/**
@@ -693,6 +695,11 @@ class UCF_Degree_Import {
 			case 'Minor':
 				$program_types[] = $this->level;
 				break;
+		}
+
+		// Allow overrides by themes/other plugins
+		if ( has_filter( 'ucf_degree_get_program_types' ) ) {
+			$program_types = apply_filters( 'ucf_degree_get_program_types', $program_types, $this );
 		}
 
 		return $program_types;

--- a/importers/degree-importer.php
+++ b/importers/degree-importer.php
@@ -56,7 +56,7 @@ class UCF_Degree_Importer {
 		$this->api_key = $api_key;
 		$this->do_writebacks = $do_writebacks;
 		$this->preserve_hierarchy = $preserve_hierarchy;
-		$this->program_types = apply_filters( 'ucf_degree_imported_program_types', $default_program_types );
+		$this->program_types = apply_filters( 'ucf_degree_imported_program_types', $this->default_program_types );
 	}
 
 	/**

--- a/importers/degree-importer.php
+++ b/importers/degree-importer.php
@@ -368,7 +368,7 @@ Degree Total    : {$degree_total}
 		$import_progress = \WP_CLI\Utils\make_progress_bar( 'Importing degree plans...', count( $this->search_results ) );
 
 		foreach( $this->search_results as $ss_program ) {
-			if ( $ss_program->parent_program === null ) {
+			if ( $ss_program->parent_program === null || ! $this->preserve_hierarchy ) {
 				// Import the degree as a new WP Post draft, or update existing
 				$degree = new UCF_Degree_Import( $ss_program , $this->api_key, $this->preserve_hierarchy );
 				$degree->import_post();
@@ -392,7 +392,7 @@ Degree Total    : {$degree_total}
 		$import_progress = \WP_CLI\Utils\make_progress_bar( 'Importing degree subplans...', count( $this->search_results ) );
 
 		foreach( $this->search_results as $ss_program ) {
-			if ( $ss_program->parent_program !== null ) {
+			if ( $ss_program->parent_program !== null && $this->preserve_hierarchy ) {
 				// Import the degree as a new WP Post draft, or update existing
 				$degree = new UCF_Degree_Import( $ss_program, $this->api_key, $this->preserve_hierarchy );
 				$degree->import_post();
@@ -419,7 +419,7 @@ Degree Total    : {$degree_total}
 		$post_id = $degree->post_id;
 		$new_posts = $existing_posts = $updated_posts = array();
 
-		if ( $degree->is_subplan ) {
+		if ( $degree->is_subplan && $this->preserve_hierarchy ) {
 			$new_posts      = &$this->new_subplan_posts;
 			$existing_posts = &$this->existing_subplan_posts;
 			$updated_posts  = &$this->updated_subplan_posts;

--- a/includes/ucf-degree-wpcli.php
+++ b/includes/ucf-degree-wpcli.php
@@ -32,6 +32,15 @@ class UCF_Degree_Commands extends WP_CLI_Command {
 	 *   - false
 	 * ---
 	 *
+	 * [--force_delete_stale=<force_delete_stale>]
+	 * : If enabled, stale degrees will bypass trash status and be permanently deleted.
+	 * ---
+	 * default: true
+	 * options:
+	 *   - true
+	 *   - false
+	 * ---
+	 *
 	 * ## EXAMPLES
 	 *
 	 * # Imports degrees from the production search service.
@@ -44,6 +53,7 @@ class UCF_Degree_Commands extends WP_CLI_Command {
 		$api_key         = isset( $assoc_args['api_key'] ) && !empty( $assoc_args['api_key'] ) ? trim( $assoc_args['api_key'] ) : trim( UCF_Degree_Config::get_option_or_default( 'ucf_degree_api_key' ) );
 		$do_writebacks   = isset( $assoc_args['enable_search_writebacks'] ) ? filter_var( $assoc_args['enable_search_writebacks'], FILTER_VALIDATE_BOOLEAN ) : false;
 		$preserve_hierarchy = isset( $assoc_args['preserve_hierarchy'] ) ? filter_var( $assoc_args['preserve_hierarchy'], FILTER_VALIDATE_BOOLEAN ) : true;
+		$force_delete_stale = isset( $assoc_args['force_delete_stale'] ) ? filter_var( $assoc_args['force_delete_stale'], FILTER_VALIDATE_BOOLEAN ) : true;
 		$additional_args = UCF_Degree_Config::get_option_or_default( 'search_filter' );
 
 		if ( empty( $api_base_url ) ) {
@@ -55,7 +65,7 @@ class UCF_Degree_Commands extends WP_CLI_Command {
 		}
 
 		// Do import
-		$import = new UCF_Degree_Importer( $api_base_url, $api_key, $do_writebacks, $additional_args, $preserve_hierarchy );
+		$import = new UCF_Degree_Importer( $api_base_url, $api_key, $do_writebacks, $additional_args, $preserve_hierarchy, $force_delete_stale );
 		try {
 			$import->import();
 		}

--- a/includes/ucf-degree-wpcli.php
+++ b/includes/ucf-degree-wpcli.php
@@ -28,8 +28,8 @@ class UCF_Degree_Commands extends WP_CLI_Command {
 	 * ---
 	 * default: true
 	 * options:
-	 * 	- true
-	 * 	- false
+	 *   - true
+	 *   - false
 	 * ---
 	 *
 	 * ## EXAMPLES

--- a/includes/ucf-degree-wpcli.php
+++ b/includes/ucf-degree-wpcli.php
@@ -23,6 +23,15 @@ class UCF_Degree_Commands extends WP_CLI_Command {
      *   - false
      * ---
 	 *
+	 * [--preserve_hierarchy=<preserve_hierarchy>]
+	 * : If enabled, will preserve parent/child relationship in degree data.
+	 * ---
+	 * default: true
+	 * options:
+	 * 	- true
+	 * 	- false
+	 * ---
+	 *
 	 * ## EXAMPLES
 	 *
 	 * # Imports degrees from the production search service.
@@ -34,6 +43,7 @@ class UCF_Degree_Commands extends WP_CLI_Command {
 		$api_base_url    = isset( $assoc_args['api_base_url'] ) && !empty( $assoc_args['api_base_url'] ) ? trim( $assoc_args['api_base_url'] ) : trim( UCF_Degree_Config::get_option_or_default( 'ucf_degree_api_base_url' ) );
 		$api_key         = isset( $assoc_args['api_key'] ) && !empty( $assoc_args['api_key'] ) ? trim( $assoc_args['api_key'] ) : trim( UCF_Degree_Config::get_option_or_default( 'ucf_degree_api_key' ) );
 		$do_writebacks   = isset( $assoc_args['enable_search_writebacks'] ) ? filter_var( $assoc_args['enable_search_writebacks'], FILTER_VALIDATE_BOOLEAN ) : false;
+		$preserve_hierarchy = isset( $assoc_args['preserve_hierarchy'] ) ? filter_var( $assoc_args['preserve_hierarchy'], FILTER_VALIDATE_BOOLEAN ) : true;
 		$additional_args = UCF_Degree_Config::get_option_or_default( 'search_filter' );
 
 		if ( empty( $api_base_url ) ) {
@@ -45,7 +55,7 @@ class UCF_Degree_Commands extends WP_CLI_Command {
 		}
 
 		// Do import
-		$import = new UCF_Degree_Importer( $api_base_url, $api_key, $do_writebacks, $additional_args );
+		$import = new UCF_Degree_Importer( $api_base_url, $api_key, $do_writebacks, $additional_args, $preserve_hierarchy );
 		try {
 			$import->import();
 		}


### PR DESCRIPTION
Adds the following modifications to the degree importer:

**New importer options:**

`preserve_hierarchy`
- Set to `true` by default.  When disabled, the plan/subplan hierarchy from the search service will not be carried over into imported degree posts (all degrees will be non-hierarchical/flat).

`force_delete_stale`
- Set to `true` by default.  When disabled, stale degrees will be moved to trash during the import process instead of being permanently deleted.

**New filter hooks:**

`ucf_degree_imported_program_types`
- Allows for overrides to the default set of `program_type` terms created by the degree importer.

`ucf_degree_import_results`
- Allows the search service results and result count to be modified by other themes/plugins before the import process begins.

`ucf_degree_get_program_types`
- Allows other themes/plugins to override what `program_type` term(s) get assigned to individual degrees.

`ucf_degree_set_post_data`
- Allows overriding of specific post data (`post_title`, `post_name`, `post_status`,  `post_author`) before new degree posts are created in the import process.
- `post_status` changes are limited to anything except "publish" to prevent unintentional slug incrementing during the import process.