### PR TITLE
Existing post retrieval improvements

### DIFF
--- a/importers/degree-importer.php
+++ b/importers/degree-importer.php
@@ -634,7 +634,7 @@ class UCF_Degree_Import {
 		$this->program       = $program;
 		$this->plan_code     = $program->plan_code;
 		$this->subplan_code  = $program->subplan_code;
-		$this->degree_id     = $program->plan_code. ' ' . $program->subplan_code;
+		$this->degree_id     = $program->plan_code . ' ' . $program->subplan_code;
 		$this->api_id        = $program->id;
 		$this->name          = $program->name;
 		$this->online        = $program->online;

--- a/importers/degree-importer.php
+++ b/importers/degree-importer.php
@@ -300,8 +300,7 @@ Degree Total    : {$degree_total}
 					),
 					array(
 						'key'      => 'degree_subplan_code',
-						'value'    => '',
-						'compare'  => '='
+						'compare'  => 'NOT EXISTS'
 					)
 				),
 				array(

--- a/importers/degree-importer.php
+++ b/importers/degree-importer.php
@@ -239,7 +239,9 @@ Degree Total    : {$degree_total}
 		// other themes/plugins.
 		// Functions passed to this filter MUST return both $results AND $count
 		// as a two-value array.
-		list( $results, $count ) = apply_filters( 'ucf_degree_import_results', $results, $count, $this->api_key );
+		if ( has_filter( 'ucf_degree_import_results' ) ) {
+			list( $results, $count ) = apply_filters( 'ucf_degree_import_results', $results, $count, $this->api_key );
+		}
 
 		$this->result_count = $count;
 

--- a/importers/degree-importer.php
+++ b/importers/degree-importer.php
@@ -904,20 +904,10 @@ class UCF_Degree_Import {
 			'post_type'      => 'degree',
 			'posts_per_page' => 1,
 			'post_status'    => array( 'publish', 'draft' ),
-			// post_parent will be 0 for plans (returning only degrees with
-			// no children), or a valid post ID for subplans
-			'post_parent'    => $this->parent_post_id,
 			'meta_query'     => array(
 				array(
 					'key'   => 'degree_id',
 					'value' => $this->degree_id
-				)
-			),
-			'tax_query'      => array(
-				array(
-					'taxonomy' => 'program_types',
-					'field'    => 'name',
-					'terms'    => $this->program_types
 				)
 			)
 		);

--- a/importers/degree-importer.php
+++ b/importers/degree-importer.php
@@ -946,7 +946,7 @@ class UCF_Degree_Import {
 	private function get_existing_post() {
 		$args = array(
 			'post_type'      => 'degree',
-			'posts_per_page' => -1,
+			'posts_per_page' => 1,
 			'post_status'    => array( 'publish', 'draft' ),
 			'meta_query'     => array(
 				array(

--- a/importers/degree-importer.php
+++ b/importers/degree-importer.php
@@ -636,7 +636,7 @@ class UCF_Degree_Import {
 		$this->subplan_code  = $program->subplan_code;
 		$this->degree_id     = $program->plan_code . ' ' . $program->subplan_code;
 		$this->api_id        = $program->id;
-		$this->name          = $program->name;
+		$this->name          = $this->get_name();
 		$this->online        = $program->online;
 		$this->catalog_url   = $program->catalog_url;
 		$this->career        = $program->career;
@@ -656,6 +656,17 @@ class UCF_Degree_Import {
 
 		$this->post_meta  = $this->get_post_metadata();
 		$this->post_terms = $this->get_post_terms();
+	}
+
+	/**
+	 * Returns the degree's name.
+	 *
+	 * @author Jo Dickson
+	 * @since 3.0.2
+	 * @return string
+	 */
+	private function get_name() {
+		return apply_filters( 'ucf_degree_get_imported_name', $this->program->name, $this->program );
 	}
 
 	/**


### PR DESCRIPTION
Modified the importer's `get_existing_plan_posts()` and `get_existing_subplan_posts()` methods to retrieve existing posts by plan code + subplan code values, instead of post parent relationships.  By disassociating post parent/child relationships and program plan/subplan relationships, we improve the reliability of accurately determining _actual_ existing plans and subplans when degree relationships have been modified during the import process, and subsequently eliminate a lot of `preserve_hierarchy` checks in the importer code.

Other:
- Added `has_filter()` check around `ucf_degree_import_results` hook to prevent errors when `$count` doesn't get set properly.
- Added `ucf_degree_get_imported_name` hook for modifying imported degree names.  By using this hook, the degree's short name and slug inherit any changes made to the degree name.