### PR TITLE
Added post_parent as an overidable shortcode attribute

### DIFF
--- a/shortcodes/ucf-degree-list-shortcode.php
+++ b/shortcodes/ucf-degree-list-shortcode.php
@@ -39,8 +39,8 @@ if ( ! class_exists( 'UCF_Degree_List_Shortcode' ) ) {
 				);
 			}
 
-			if ( $atts['post_parent'] && is_int( $atts['post_parent'] ) ) {
-				$args['post_parent'] = $atts['post_parent'];
+			if ( isset( $atts['post_parent'] ) && is_numeric( $atts['post_parent'] ) ) {
+				$args['post_parent'] = intval( $atts['post_parent'] );
 			}
 
 			$items = get_posts( $args );

--- a/shortcodes/ucf-degree-list-shortcode.php
+++ b/shortcodes/ucf-degree-list-shortcode.php
@@ -18,7 +18,8 @@ if ( ! class_exists( 'UCF_Degree_List_Shortcode' ) ) {
 				'groupby'       => null,
 				'groupby_field' => null,
 				'filter_by_tax' => null,
-				'terms'         => null
+				'terms'         => null,
+				'post_parent'   => null,
 			), $atts, 'degree-list' );
 
 			$args = array(
@@ -36,6 +37,10 @@ if ( ! class_exists( 'UCF_Degree_List_Shortcode' ) ) {
 						'terms'    => explode( ',', $atts['terms'] )
 					)
 				);
+			}
+
+			if ( $atts['post_parent'] && is_int( $atts['post_parent'] ) ) {
+				$args['post_parent'] = $atts['post_parent'];
 			}
 
 			$items = get_posts( $args );


### PR DESCRIPTION
Enhancements:
* Added a field for `post_parent` which should allow the shortcode only to fetch "parent" programs by setting it to `0` or displaying only child programs by setting it to the ID of the parent post.
* We will be setting this value to `0` by default in the Online-Theme by using the `shortcode_atts_degree-list` filter. 