### PR TITLE
Added bugfix for when both program_types and colleges are both defined

### DIFF
--- a/includes/ucf-degree-api.php
+++ b/includes/ucf-degree-api.php
@@ -135,6 +135,12 @@ if ( ! class_exists( 'UCF_Degree_API' ) ) {
 				);
 			}
 
+			if ( isset(  $args['tax_query'] ) &&
+				count( $args['tax_query'] ) > 1 )
+			{
+				$args['tax_query']['relation'] = 'AND';
+			}
+
 			$query = new WP_Query( $args );
 
 			// Don't call the normal query. Use relevansse query.

--- a/includes/ucf-degree-api.php
+++ b/includes/ucf-degree-api.php
@@ -135,9 +135,7 @@ if ( ! class_exists( 'UCF_Degree_API' ) ) {
 				);
 			}
 
-			if ( isset(  $args['tax_query'] ) &&
-				count( $args['tax_query'] ) > 1 )
-			{
+			if ( isset(  $args['tax_query'] ) && count( $args['tax_query'] ) > 1 ) {
 				$args['tax_query']['relation'] = 'AND';
 			}
 


### PR DESCRIPTION
Bug Fixes:
* Explicitly defines the tax_query as `AND` when both `program_types` and `colleges` are passed in.