### PR TITLE
Degree interests importer

### DIFF
--- a/importers/degree-interests-importer.php
+++ b/importers/degree-interests-importer.php
@@ -142,7 +142,7 @@ The follow programs could not be found:
         if ( ! $degree ) return false;
 
         // Append terms to the degree.
-        $retval = wp_set_post_terms( $degree->ID, array( $interest->term_id ), 'interests', true );
+        $retval = wp_set_post_terms( $degree->ID, array( $interest->term_id ), 'interests' );
 
         // $retval will be an array if successful
         return is_array( $retval );

--- a/importers/degree-interests-importer.php
+++ b/importers/degree-interests-importer.php
@@ -56,7 +56,8 @@ Programs Processed : {$this->total_programs_processed}
 Programs Updated   : {$this->programs_updated}
 Programs Errors    : {$this->programs_errors}
 
-The follow programs could not be found:";
+The follow programs could not be found:
+";
         foreach( $this->could_not_add as $program ) {
             $retval .= "\n{$program}";
         }

--- a/importers/degree-interests-importer.php
+++ b/importers/degree-interests-importer.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Class for importing interests and
+ * assigning them to degrees
+ */
+class UCF_Degree_Interests_Importer {
+    private
+        $file,
+        $interests,
+        $interests_updated = 0,
+        $interests_added = 0,
+        $interests_errors = 0,
+        $programs_added = 0,
+        $rograms_errors = 0,
+        $could_not_add = array(),
+        $total_terms_processed = 0,
+        $total_programs_processed = 0;
+
+    /**
+     * Constructs the importer class.
+     * Will return an exception if the filepath
+     * provided is not valid or is not valid JSON.
+     * @author Jim Barnes
+     * @since 3.1.0
+     * @param string $file_path The path to the import file
+     */
+    public function __construct( $file_path ) {
+        $this->file = file_get_contents( $file_path );
+
+        if ( $this->file === false ) {
+            throw new Exception(
+                'Unable to locate or load the filepath provided.'
+            );
+        }
+
+        $this->interests = json_decode( $this->file );
+
+        if ( ! $this->interests ) {
+            throw new Exception(
+                'Unable to decode the JSON within the specified file.'
+            );
+        }
+    }
+
+    public function get_stats() {
+        $retval =
+"
+Finished importing interests.
+
+Interests Processed: {$this->total_terms_processed}
+Interests Added    : {$this->interests_added}
+Interests Updated  : {$this->interests_updated}
+Interests Errors   : {$this->interests_errors}
+
+Programs Processed : {$this->total_programs_processed}
+Programs Updated   : {$this->programs_updated}
+Programs Errors    : {$this->programs_errors}
+
+The follow programs could not be found:";
+        foreach( $this->could_not_add as $program ) {
+            $retval .= "\n{$program}";
+        }
+
+        $retval .= "\n";
+
+        return $retval;
+    }
+
+    /**
+     * Imports the interests into the site
+     * and assigns all provided degrees.
+     * @author Jim Barnes
+     * @since 3.1.0
+     */
+    public function import() {
+        foreach( $this->interests as $interest ) {
+            $clean_name = $this->clean_name( $interest->name );
+
+            $term = $this->add_or_get_interest( $clean_name, $interest->name, $interest->slug );
+
+            foreach( $interest->programs as $program ) {
+                $added = $this->add_degree_to_interest( $program, $term );
+
+                if ( $added ) {
+                    $this->programs_updated++;
+                } else {
+                    $this->programs_errors++;
+                    $this->could_not_add[] = $program;
+                }
+
+                $this->total_programs_processed++;
+            }
+
+            $this->total_terms_processed++;
+        }
+    }
+
+    /**
+     * Adds or returns an existing interest.
+     * @author Jim Barnes
+     * @since 3.1.0
+     * @param string $name The interest name
+     * @param string $display_text The interest's display text
+     * @param string $slug The interest's desired slug.
+     * @return WP_Term The interest object
+     */
+    private function add_or_get_interest( $clean_name, $name, $slug ) {
+        $term = get_term_by( 'name', $clean_name, 'interests' );
+
+        if ( $term ) {
+            $this->interests_updated++;
+            return $term;
+        }
+
+        $term = wp_insert_term(
+            $clean_name,
+            'interests',
+            array(
+                'slug' => $slug
+            )
+        );
+
+        add_term_meta( $term->term_id, 'interests_display_text', $name );
+
+        $this->interests_added++;
+
+        return $term;
+    }
+
+    /**
+     * Adds the provided interest to the provided degree
+     * @author Jim Barnes
+     * @since 3.1.0
+     * @param string $degree_name The name of the degree to add the interest to
+     * @param WP_Term $interest The interests term to add to the degree
+     * @return bool True if the degree is found and interest added, false if not.
+     */
+    private function add_degree_to_interest( $degree_name, $interest ) {
+        $degree = get_page_by_title( $degree_name, 'OBJECT', 'degree' );
+
+        if ( ! $degree ) return false;
+
+        // Append terms to the degree.
+        $retval = wp_set_post_terms( $degree->ID, array( $interest->term_id ), 'interests', true );
+
+        // $retval will be an array if successful
+        return is_array( $retval );
+    }
+
+    /**
+     * Removes commas from the term
+     * @author Jim Barnes
+     * @since 3.1.0
+     * @param string $name The interest name
+     * @return string
+     */
+    private function clean_name( $name ) {
+        return str_replace( ',', '', $name );
+    }
+}

--- a/includes/ucf-degree-wpcli.php
+++ b/includes/ucf-degree-wpcli.php
@@ -54,4 +54,36 @@ class UCF_Degree_Commands extends WP_CLI_Command {
 		}
 		WP_CLI::success( $import->get_stats() );
 	}
+
+	/**
+	 * Imports interests from a JSON file
+	 *
+	 * ## OPTIONS
+	 *
+	 * <filepath>
+	 * : The filepath to a valid JSON file containing interests and assigned program names.
+	 *
+	 * ## EXAMPLES
+	 *
+	 * # Imports interests from a file called interests.json in a home directory
+	 * $ wp degrees import_intersts ~/interests.json
+	 *
+	 * @when after_wp_load
+	 */
+	public function import_interests( $args, $assoc_args ) {
+		list( $filepath ) = $args;
+
+		if ( empty( $filepath ) ) {
+			WP_CLI::error( 'A filepath to a valid JSON file must be provided.' );
+		}
+
+		$import = new UCF_Degree_Interests_Importer( $filepath );
+		try {
+			$import->import();
+			WP_CLI::success( $import->get_stats() );
+		}
+		catch( Exception $e ) {
+			WP_CLI::error( $e->getMessage(), $e->getCode() );
+		}
+	}
 }

--- a/includes/ucf-degree-wpcli.php
+++ b/includes/ucf-degree-wpcli.php
@@ -54,7 +54,9 @@ class UCF_Degree_Commands extends WP_CLI_Command {
 		}
 		WP_CLI::success( $import->get_stats() );
 	}
+}
 
+class UCF_Degree_Interests_Commands extends WP_CLI_Command {
 	/**
 	 * Imports interests from a JSON file
 	 *
@@ -66,11 +68,11 @@ class UCF_Degree_Commands extends WP_CLI_Command {
 	 * ## EXAMPLES
 	 *
 	 * # Imports interests from a file called interests.json in a home directory
-	 * $ wp degrees import_intersts ~/interests.json
+	 * $ wp interests import ~/interests.json
 	 *
 	 * @when after_wp_load
 	 */
-	public function import_interests( $args, $assoc_args ) {
+	public function import( $args, $assoc_args ) {
 		list( $filepath ) = $args;
 
 		if ( empty( $filepath ) ) {

--- a/ucf-degree-cpt.php
+++ b/ucf-degree-cpt.php
@@ -40,6 +40,7 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	include_once 'importers/degree-interests-importer.php';
 
 	WP_CLI::add_command( 'degrees', 'UCF_Degree_Commands' );
+	WP_CLI::add_command( 'interests', 'UCF_Degree_Interests_Commands' );
 }
 
 

--- a/ucf-degree-cpt.php
+++ b/ucf-degree-cpt.php
@@ -37,6 +37,7 @@ include_once 'shortcodes/ucf-degree-career-paths-shortcode.php';
 if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	include_once 'includes/ucf-degree-wpcli.php';
 	include_once 'importers/degree-importer.php';
+	include_once 'importers/degree-interests-importer.php';
 
 	WP_CLI::add_command( 'degrees', 'UCF_Degree_Commands' );
 }


### PR DESCRIPTION
Enhancements:
* Added importer for interests. The interests schema is as follows:
```
[
   {
      "name": "Interest name to be assigned to $term->name",
      "slug": "Interest slug to be assigned to $term->slug",
      "programs": [
         "Program Name 1",
         "Program Name 2"
      ]
   }, // Rinse and repeat
]
```

Note: The `name` field will be passed through a `clean_name` function that removes commas, but the original name will remain intact in the `interests_display_text` custom meta field.