### PR TITLE
Sorted degrees by taxonomy - new hooks, bugfix

### DIFF
--- a/includes/ucf-degree-utils.php
+++ b/includes/ucf-degree-utils.php
@@ -32,7 +32,7 @@ if ( ! function_exists( 'ucf_degree_append_meta' ) ) {
 	}
 }
 
-if ( ! function_exists( 'ucf_degree_group_by_tax_term' ) ) {
+if ( ! function_exists( 'ucf_degree_group_posts_by_tax' ) ) {
 	function ucf_degree_group_posts_by_tax( $taxonomy_slug, $posts ) {
 		$retval = array();
 

--- a/includes/ucf-degree-utils.php
+++ b/includes/ucf-degree-utils.php
@@ -54,7 +54,7 @@ if ( ! function_exists( 'ucf_degree_group_posts_by_tax' ) ) {
 			}
 		}
 
-		return $retval;
+		return apply_filters( 'ucf_degree_group_posts_by_tax', $retval, $taxonomy_slug, $posts );
 	}
 }
 

--- a/shortcodes/ucf-degree-list-shortcode.php
+++ b/shortcodes/ucf-degree-list-shortcode.php
@@ -52,6 +52,7 @@ if ( ! class_exists( 'UCF_Degree_List_Shortcode' ) ) {
 				}
 
 				usort( $items, array( 'UCF_Degree_List_Shortcode', 'sort_grouped_degrees' ) );
+				$items = apply_filters( 'ucf_degree_list_sort_grouped_degrees', $items );
 			}
 
 			ob_start();


### PR DESCRIPTION
- Fixes an incorrect function name in `function_exists()` call for `ucf_degree_group_posts_by_tax`. Fixes #74.
- Adds a hook for modifying grouped degree lists by taxonomy (`ucf_degree_group_posts_by_tax`)
- Adds a hook for modifying the sort order of grouped degree lists outputted by the `[degree-list]` shortcode (`ucf_degree_list_sort_grouped_degrees`)