### PR TITLE
Subplan parent ID fetch update

### DIFF
--- a/common/ucf-degree-common.php
+++ b/common/ucf-degree-common.php
@@ -14,7 +14,7 @@ if ( ! class_exists( 'UCF_Degree_Common' ) ) {
 		 * @return mixed JSON-decoded object or false on failure
 		 */
 		public static function fetch_json( $url ) {
-			$response      = wp_remote_get( $url, array( 'timeout' => 5 ) );
+			$response      = wp_remote_get( $url, array( 'timeout' => 10 ) );
 			$response_code = wp_remote_retrieve_response_code( $response );
 			$result        = false;
 

--- a/common/ucf-degree-common.php
+++ b/common/ucf-degree-common.php
@@ -153,6 +153,8 @@ if ( ! class_exists( 'UCF_Degree_Common' ) ) {
 			$plan_code = $params['plan_code'];
 			$subplan_code = isset( $params['subplan_code'] ) ? $params['subplan_code'] : null;
 
+			if ( ! is_array( $results ) ) return false;
+
 			foreach( $results as $result ) {
 				if (
 					$result->plan_code === $plan_code &&

--- a/importers/degree-importer.php
+++ b/importers/degree-importer.php
@@ -811,14 +811,15 @@ class UCF_Degree_Import {
 		$id = $parent_program = null;
 
 		if ( $this->is_subplan ) {
-			$params = array();
+			$id = $this->program->parent_program->id;
+			// $params = array();
 
-			if ( $this->api_key ) $params['key'] = $this->api_key;
+			// if ( $this->api_key ) $params['key'] = $this->api_key;
 
-			$parent_program = UCF_Degree_Common::fetch_api_value( $this->program->parent_program->url, $params );
-			if ( $parent_program ) {
-				$id = $parent_program->id;
-			}
+			// $parent_program = UCF_Degree_Common::fetch_api_value( $this->program->parent_program->url, $params );
+			// if ( $parent_program ) {
+			// 	$id = $parent_program->id;
+			// }
 		}
 
 		return $id;

--- a/importers/degree-importer.php
+++ b/importers/degree-importer.php
@@ -808,18 +808,10 @@ class UCF_Degree_Import {
 	 * @return mixed | Parent program ID integer, or null on failure
 	 */
 	private function get_parent_program_id() {
-		$id = $parent_program = null;
+		$id = null;
 
 		if ( $this->is_subplan ) {
 			$id = $this->program->parent_program->id;
-			// $params = array();
-
-			// if ( $this->api_key ) $params['key'] = $this->api_key;
-
-			// $parent_program = UCF_Degree_Common::fetch_api_value( $this->program->parent_program->url, $params );
-			// if ( $parent_program ) {
-			// 	$id = $parent_program->id;
-			// }
 		}
 
 		return $id;


### PR DESCRIPTION
- Updated `get_parent_program_id()` to return the program's parent ID from `$this->program->parent_program->id` instead of fetching per-parent API results.  See https://github.com/UCF/Search-Service-Django/pull/28.
- Increased API fetch timeout from 5 seconds to 10
- Added check in `UCF_Degree_Common::return_verified_result()` to ensure `$results` is an array before attempting to loop through it.  Resolves #83 .