### PR TITLE
Updated custom filters to use correct parameters

### DIFF
--- a/includes/ucf-degree-search-custom-filters.php
+++ b/includes/ucf-degree-search-custom-filters.php
@@ -14,7 +14,7 @@ if ( ! class_exists( 'UCF_Degree_Search_Custom_Filters' ) ) {
 		 * @param $wp_query WP_Query | Global WP_Query reference
 		 * @return string | The modified order_by clause.
 		 **/
-		public static function order_by_tax_orderby( $orderby, &$wp_query ) {
+		public static function order_by_tax_orderby( $orderby, $wp_query ) {
 			global $wpdb;
 
 			if ( UCF_Degree_Search_Custom_Filters::valid_taxonomy( $wp_query->get( 'order_by_taxonomy' ) ) ) {

--- a/includes/ucf-degree-utils.php
+++ b/includes/ucf-degree-utils.php
@@ -89,7 +89,7 @@ if ( ! function_exists( 'ucf_degree_search_join_filter' ) ) {
 	* @param $join string | The join string to be modified
 	* @param $wp_query WP_Query passed by reference
 	**/
-	function ucf_degree_search_join_filter( $join, &$wp_query ) {
+	function ucf_degree_search_join_filter( $join, $wp_query ) {
 		global $wpdb;
 
 		if ( isset( $wp_query->query['degree_search'] ) && $wp_query->query_vars['post_type'] === 'degree' ) {
@@ -113,7 +113,7 @@ if ( ! function_exists( 'ucf_degree_search_where_filter' ) ) {
 	 * @param $where string | The where string to be modified
 	 * @param $wp_query WP_Query passed by reference
 	 **/
-	function ucf_degree_search_where_filter( $where, &$wp_query ) {
+	function ucf_degree_search_where_filter( $where, $wp_query ) {
 		global $wpdb;
 
 		if ( isset( $wp_query->query['degree_search'] ) && $wp_query->query_vars['post_type'] === 'degree' ) {
@@ -138,7 +138,7 @@ if ( ! function_exists( 'ucf_degree_search_groupby_filter' ) ) {
 	 * @param $groupby string | The groupby string to be modified
 	 * @param $wp_query WP_Query passed by reference
 	 **/
-	function ucf_degree_search_groupby_filter( $groupby, &$wp_query ) {
+	function ucf_degree_search_groupby_filter( $groupby, $wp_query ) {
 		global $wpdb;
 
 		if ( isset( $wp_query->query['degree_search'] ) && $wp_query->query_vars['post_type'] === 'degree' ) {

--- a/includes/ucf-degree-utils.php
+++ b/includes/ucf-degree-utils.php
@@ -96,7 +96,7 @@ if ( ! function_exists( 'ucf_degree_search_join_filter' ) ) {
 			$join .= " LEFT JOIN $wpdb->term_relationships as wtr ON ($wpdb->posts.ID = wtr.object_id)";
 			$join .= " LEFT JOIN $wpdb->term_taxonomy as wtt ON (wtr.term_taxonomy_id = wtt.term_taxonomy_id)";
 			$join .= " LEFT JOIN $wpdb->terms as wt ON (wtt.term_id = wt.term_id)";
-			$join .= " left join $wpdb->postmeta as wpm ON ($wpdb->posts.ID = wpm.post_id)";
+			$join .= " LEFT JOIN $wpdb->postmeta as wpm ON ($wpdb->posts.ID = wpm.post_id)";
 		}
 
 		return $join;


### PR DESCRIPTION
Bug Fixes:
* Corrected parameters on custom where, join, group by and order by filters. The `$wp_query` parameter is passed in as a reference, but shouldn't have a reference identifier in the function definition. 