### PR TITLE
Write-backs

### DIFF
--- a/admin/ucf-degree-config.php
+++ b/admin/ucf-degree-config.php
@@ -95,7 +95,7 @@ if ( ! class_exists( 'UCF_Degree_Config' ) ) {
 		 * @return array
 		 */
 		private static function get_api_select_options( $values, $empty_val='-----------' ) {
-			$retval = array( '' => $empty_val );
+			$retval = array( 0 => $empty_val );
 
 			if ( $values ) {
 				$retval = array_merge( $retval, $values );

--- a/common/ucf-degree-common.php
+++ b/common/ucf-degree-common.php
@@ -254,7 +254,7 @@ if ( ! class_exists( 'UCF_Degree_Common' ) ) {
 		 * @return void
 		 */
 		private static function update_profile( $post_id, $result ) {
-			$prof_type = (int)UCF_Degree_Config::get_option_or_default( 'prof_type' );
+			$prof_type = UCF_Degree_Config::get_option_or_default( 'prof_type' );
 			$base_url  = UCF_Degree_Config::get_option_or_default( 'api_base_url' );
 			$key       = UCF_Degree_Config::get_option_or_default( 'api_key' );
 			$match     = false;


### PR DESCRIPTION
Very small update to the `get_api_select_options` function. Setting the empty value to an empty string was causing the array to be merged as a standard (not associative) array, cause the `id` for each option which was previous holding a primary key (like the profile type id, or the description type id) to be reset to the index of the array. Setting this value to an integer ensures the associative integrity of the array is preserved.