### PR TITLE
Two column layout adjustments

### DIFF
--- a/layouts/ucf-degree-list-twocol.php
+++ b/layouts/ucf-degree-list-twocol.php
@@ -43,8 +43,8 @@ if ( ! function_exists( 'ucf_degree_list_display_twocol_grouped' ) ) {
 }
 
 /**
- * Enqueues twocol assets if degree-list shortcode layout attr is
- * set to 'twocol' and the groupby attr is empty.
+ * Enqueues twocol assets if degree-list shortcode
+ * layout attr is set to 'twocol'.
  *
  * @since 3.2.6
  * @author Cadie Stockman
@@ -59,7 +59,7 @@ if ( ! function_exists( 'ucf_degree_list_enqueue_twocol_assets' ) ) {
 			return $output;
 		}
 
-		if ( isset( $attr['layout'] ) && $attr['layout'] === 'twocol' && empty( $attr['groupby'] ) ) {
+		if ( isset( $attr['layout'] ) && $attr['layout'] === 'twocol' ) {
 			$plugin_data = get_plugin_data( UCF_DEGREE__PLUGIN_FILE, false, false );
 			$version     = $plugin_data['Version'];
 

--- a/layouts/ucf-degree-list-twocol.php
+++ b/layouts/ucf-degree-list-twocol.php
@@ -21,55 +21,17 @@ if ( ! function_exists( 'ucf_degree_list_display_twocol' ) ) {
 
 if ( ! function_exists( 'ucf_degree_list_display_twocol_grouped' ) ) {
 	function ucf_degree_list_display_twocol_grouped( $content, $items, $args, $grouped ) {
-		$item_count = 0;
-
-		if ( $items ) {
-			foreach( $items as $group ) {
-				$item_count += count( $group['posts'] );
-			}
-		}
-
-		// Figure out where we're going to split the columns
-		$col_split = ceil( $item_count / 2 );
-		$col_index = 0;
-		$split = false;
-
-		// Reset item count variable
-		// We're going to use it to keep track of where we are now.
-		$item_count = 0;
-
 		ob_start();
-
-		if ( $items ):
-			foreach( $items as $index => $group ) :
-				$item_count += count( $group['posts'] );
-
-
-				if ( $index === 0 ) :
-			?>
-				<div class="row">
-					<div class="col-lg-6">
-			<?php elseif ( $col_index === 1 && $split === false ) : $split = true; ?>
-					</div>
-
-					<div class="col-lg-6">
-			<?php endif;  ?>
-
+		if ( $items ) :
+			foreach ( $items as $index => $group ) :
+		?>
 			<div class="degree-list-group">
 				<h3 class="degree-list-heading"><?php echo $group['group_name']; ?></h3>
-				<?php echo ucf_degree_list_display_classic( '', $group['posts'], $args, $grouped ); ?>
+				<?php echo ucf_degree_list_display_twocol( '', $group['posts'], $args, $grouped ); ?>
 			</div>
 		<?php
-			// If we're over our split point,
-			// move onto the next column.
-			if ( $item_count > $col_split ) :
-				$col_index = 1;
-			endif;
-
 			endforeach;
-		?>
-		</div></div>
-		<?php
+
 		else:
 			echo '<p>No results found.</p>';
 		endif;

--- a/layouts/ucf-degree-list-twocol.php
+++ b/layouts/ucf-degree-list-twocol.php
@@ -23,7 +23,7 @@ if ( ! function_exists( 'ucf_degree_list_display_twocol_grouped' ) ) {
 	function ucf_degree_list_display_twocol_grouped( $content, $items, $args, $grouped ) {
 		ob_start();
 		if ( $items ) :
-			foreach ( $items as $index => $group ) :
+			foreach ( $items as $group ) :
 		?>
 			<div class="degree-list-group">
 				<h3 class="degree-list-heading"><?php echo $group['group_name']; ?></h3>


### PR DESCRIPTION
**Description**
Adjustments were made to the `twocol_grouped` layout so that each grouping is now in its own "row" and each group's set of list items are in two columns under the headline. This allows the grouped layout to use the same column css rules as the non-grouped twocol layout.

**Motivation and Context**
These adjustments were requested in order to increase the ease of readability for each of the groupings and their list items, and to more closely match how these lists look in mobile.

**How Has This Been Tested?**
Changes viewable in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly. _*(Still need to add documentation about the `degree-list` shortcode in general, will work on that later this week)_
