### PR TITLE
Fix splitting columns in Safari and Firefox

### DIFF
--- a/src/scss/ucf-degree-list-twocol.scss
+++ b/src/scss/ucf-degree-list-twocol.scss
@@ -3,5 +3,10 @@
   .degree-list-twocol {
     column-gap: 3.5rem;
     columns: 2;
+
+    .degree-list-program {
+      break-inside: avoid;
+      page-break-inside: avoid;
+    }
   }
 }

--- a/static/css/ucf-degree-list-twocol.min.css
+++ b/static/css/ucf-degree-list-twocol.min.css
@@ -1,1 +1,1 @@
-@media (min-width:992px){.degree-list-twocol{-webkit-column-gap:3.5rem;-moz-column-gap:3.5rem;column-gap:3.5rem;-webkit-columns:2;-moz-columns:2;columns:2}}
+@media (min-width:992px){.degree-list-twocol{-webkit-column-gap:3.5rem;-moz-column-gap:3.5rem;column-gap:3.5rem;-webkit-columns:2;-moz-columns:2;columns:2}.degree-list-twocol .degree-list-program{-webkit-column-break-inside:avoid;-moz-column-break-inside:avoid;break-inside:avoid;page-break-inside:avoid}}


### PR DESCRIPTION
**Description**
Adds necessary styles in order to ensure that items displayed in columns are not split between the two in Safari and Firefox.

**Motivation and Context**
Longer list items were getting split between columns in Safari and FF.

**How Has This Been Tested?**
Tested in dev in Firefox and Safari.

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
