### PR TITLE
Degree search API endpoints - ensure taxonomy endpoints only include terms assigned to degrees

### DIFF
--- a/api/ucf-degree-search-api.php
+++ b/api/ucf-degree-search-api.php
@@ -438,7 +438,8 @@ class UCF_Degree_Search_API extends WP_REST_Controller {
 
 		$args = array(
 			'taxonomy'   => 'program_types',
-			'hide_empty' => true
+			'hide_empty' => true,
+			'post_types' => 'degree' // NOTE: requires Query Terms by Post Type plugin. Arg has no effect otherwise
 		);
 
 		$terms = get_terms( $args );
@@ -446,7 +447,7 @@ class UCF_Degree_Search_API extends WP_REST_Controller {
 		foreach( $terms as $term ) {
 			if ( isset( $retval[$term->term_id] ) ) continue;
 
-			if ( $term->count === 0 ) { continue; } // Throw out empty program_types.
+			if ( $term->count === 0 ) continue; // Throw out empty program_types.
 
 			$alias = get_term_meta( $term->term_id, 'program_types_alias', true );
 			$alias = $alias ? $alias : $term->name;
@@ -595,13 +596,14 @@ class UCF_Degree_Search_API extends WP_REST_Controller {
 
 		$args = array(
 			'taxonomy'   => 'colleges',
-			'hide_empty' => true
+			'hide_empty' => true,
+			'post_types' => 'degree' // NOTE: requires Query Terms by Post Type plugin. Arg has no effect otherwise
 		);
 
 		$terms = get_terms( $args );
 
 		foreach( $terms as $term ) {
-			if ( $term->count === 0 ) { continue; } // Throw out empty program_types.
+			if ( $term->count === 0 ) continue; // Throw out empty colleges.
 
 			$alias = get_term_meta( $term->term_id, 'colleges_alias', true );
 			$alias = $alias ? $alias : $term->name;
@@ -751,7 +753,8 @@ class UCF_Degree_Search_API extends WP_REST_Controller {
 			$terms = wp_get_object_terms( $post_ids, 'interests' );
 		} else {
 			$args = array(
-				'taxonomy' => 'interests'
+				'taxonomy'   => 'interests',
+				'post_types' => 'degree' // NOTE: requires Query Terms by Post Type plugin. Arg has no effect otherwise
 			);
 
 			if ( $search ) {
@@ -868,7 +871,8 @@ class UCF_Degree_Search_API extends WP_REST_Controller {
 			$terms = wp_get_object_terms( $post_ids, 'post_tag' );
 		} else {
 			$args = array(
-				'taxonomy' => 'post_tag'
+				'taxonomy'   => 'post_tag',
+				'post_types' => 'degree' // NOTE: requires Query Terms by Post Type plugin. Arg has no effect otherwise
 			);
 
 			if ( $search ) {

--- a/api/ucf-degree-search-api.php
+++ b/api/ucf-degree-search-api.php
@@ -913,7 +913,7 @@ class UCF_Degree_Search_API extends WP_REST_Controller {
 	 * @return array
 	 */
 	public static function get_tags_args() {
-		return get_interests_args();
+		return self::get_interests_args();
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -178,7 +178,7 @@ n/a
 
 == Installation Requirements ==
 
-None
+None, though this plugin supports the [Query Terms by Post Types plugin](https://github.com/UCF/Query-Terms-by-Post-Type), and its use is recommended if degree search REST endpoints are enabled.
 
 
 == Development & Contributing ==


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Degree-CPT-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Degree-CPT-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Updates our degree search endpoints for taxonomies to filter results using the `post_types` argument for `get_terms()`, where possible, to help ensure results only include terms assigned to at least one degree post.  The `post_types` argument is provided by the Query Terms by Post Types plugin, and will be ignored/have no effect if that plugin is not activated.

Unrelated: also fixes a static method call in `UCF_Degree_Search_API::get_tags_args()`.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
A potential solution for #116.  We could alternatively forego the use of another plugin + SQL overrides in favor of swapping out all of our `get_terms()` calls in these endpoints to fetch all degree IDs and pass them to `wp_get_object_terms()`.  There are pros and cons to either method--I think it'd be good to discuss both.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev with the Query Terms by Post Types plugin activated.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires an update to the documentation.
- [x] I have updated the documentation accordingly.
