### PR TITLE
Added filter to allow post data to be edited on import

### DIFF
--- a/importers/degree-importer.php
+++ b/importers/degree-importer.php
@@ -991,7 +991,16 @@ class UCF_Degree_Import {
 			unset( $post_data['post_date'] );
 		}
 
-		return $post_data;
+		/**
+		 * Filter that allows child themes and plugins to adjust
+		 * the formatted post data before the post is saved.
+		 * @author Jim Barnes
+		 * @since 3.2.12
+		 * @param array $post_data The already processed post data
+		 * @param UCF_Degree_Import $degree A reference to the degree import object
+		 * @return array The filtered post data array
+		 */
+		return apply_filters( 'ucf_degree_formatted_post_data', $post_data, $this );
 	}
 
 	/**


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Degree-CPT-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Degree-CPT-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds a filter that allows the core `post_data` array to be edited. The filter passes the default `post_data` object as well as the `WP_Degree_Import` object, so it has access to information about the program (i.e., is it new, program types, etc.)

**Motivation and Context**
We're using this filter on the Online importer to prevent titles from being overwritten for existing degrees.

**How Has This Been Tested?**
Importer has been run in DEV and confirmed the filter is working.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
